### PR TITLE
Cluster CCF Trace, Cluster Colors, and Cell Pop bug fixes

### DIFF
--- a/BuildTree/BuildTree.py
+++ b/BuildTree/BuildTree.py
@@ -48,7 +48,8 @@ def run_tool(args):
                                            drivers=patient_data.driver_genes,
                                            treatment_file=args.treatment_data,
                                            tumor_sizes_file=args.tumor_size,
-                                           cnv_file=args.indiv_id + '.cnvs.txt')
+                                           cnv_file=args.indiv_id + '.cnvs.txt',
+                                           cluster_color_order=args.cluster_order)
 
 
 def parse_sif_file(sif_file, mutation_ccf_file, patient_data):

--- a/BuildTree/BuildTree.py
+++ b/BuildTree/BuildTree.py
@@ -19,7 +19,7 @@ def run_tool(args):
     patient_data.preprocess_samples()
     # Building Phylogenetic Tree
     bt_engine = BuildTreeEngine(patient_data, seed=args.seed)
-    bt_engine.build_tree(n_iter=args.n_iter)
+    bt_engine.build_tree(n_iter=args.n_iter, select=args.select_tree)
     # Output and visualization
     phylogicoutput = output.PhylogicOutput.PhylogicOutput()
     # Assign Top tree to Patient

--- a/BuildTree/BuildTree.py
+++ b/BuildTree/BuildTree.py
@@ -39,6 +39,8 @@ def run_tool(args):
     cell_ancestry = bt_engine.get_cell_ancestry()
     phylogicoutput.write_constrained_ccf_tsv(constrained_ccf, cell_ancestry, args.indiv_id)
     phylogicoutput.write_cell_abundances_tsv(cell_abundance, cell_ancestry, args.indiv_id)
+    if args.cluster_ccf_trace:
+        phylogicoutput.write_cluster_ccf_trace_tsv(cp_engine.get_all_constrained_ccfs(), args.indiv_id)
     phylogicoutput.generate_html_from_tree(args.mutation_ccf_file, args.cluster_ccf_file,
                                            args.indiv_id + '_build_tree_posteriors.tsv',
                                            args.indiv_id + '_constrained_ccf.tsv',

--- a/BuildTree/BuildTreeEngine.py
+++ b/BuildTree/BuildTreeEngine.py
@@ -52,7 +52,7 @@ class BuildTreeEngine:
             average_clusters_densities[cluster_id] = normalized_average_distribution
         return average_clusters_densities
 
-    def _most_common_tree(self):
+    def _most_common_tree(self, select):
         """ Pick the most often occurring tree """
         max_iter = 0
         most_occuring_edges = None
@@ -62,6 +62,12 @@ class BuildTreeEngine:
                 max_iter = d['n_iter']
                 most_occuring_edges = d['edges']
                 cluster_densities = d['cluster_densities']
+        if select:  # manual_selection
+            for i, d in enumerate(self._mcmc_trace):
+                print i, ": ", d['edges']
+            tree_num = input('Input desired tree number based on above edges: ')
+            most_occuring_edges = self._mcmc_trace[tree_num]['edges']
+            cluster_densities = self._mcmc_trace[tree_num]['cluster_densities']
         return most_occuring_edges, self.get_average_clusters_densities(cluster_densities)
 
     @property
@@ -97,7 +103,7 @@ class BuildTreeEngine:
 
         # return {cluster_id: cluster.hist for cluster_id, cluster in self._patient.ClusteringResults.items()}
 
-    def build_tree(self, n_iter=250, burn_in=100):
+    def build_tree(self, n_iter=250, burn_in=100, select=False):
         """ Main function to construct phylogenetic tree """
         tree = Tree()
         # Create initial tree, where each cluster is a child of the clonal cluster
@@ -128,7 +134,7 @@ class BuildTreeEngine:
                 tree.set_new_edges(tree_edges_selected)
                 # Shuffle mutations
                 shuffling(self._patient.ClusteringResults, self._patient.sample_list)
-            top_tree_edges, cluster_densities = self._most_common_tree()
+            top_tree_edges, cluster_densities = self._most_common_tree(select=select)
             for cluster_id, cluster in self._patient.ClusteringResults.items():
                 cluster.set_hist(cluster_densities[cluster_id])
             tree.set_new_edges(top_tree_edges)

--- a/BuildTree/CellPopulation.py
+++ b/BuildTree/CellPopulation.py
@@ -52,8 +52,8 @@ def run_tool(args):
 def load_tree_edges_file(tree_tsv):
     reader = open(tree_tsv, 'r')
     header = reader.readline()
-    top_tree = reader.readline()
-    return eval(top_tree.split('\t')[-1].strip())
+    top_tree = reader.readline().split('\t')[-1].strip()
+    return top_tree  # todo [(item.split('-')) for item in top_tree.split(',')]
 
 
 def parse_sif_file(sif_file, mutation_ccf_file, patient_data):
@@ -103,10 +103,12 @@ def load_clustering_results(cluster_info_file, patient_data):
         cluster.set_blacklist_status()
         clustering_results[cluster_id] = cluster
 
-    # Add mutations to the cluster
-    mutations = patient_data.sample_list[0].mutations
-    for mutation in mutations:
-        cluster_id = mutation.cluster_assignment
-        clustering_results[cluster_id].add_mutation(mutation)
-
+    # Create for each cluster dictionary of mutations (key - mut_var_str and value- nd_histogram in log space)
+    mutations_nd_hist = {}
+    for mutation in patient_data.sample_list[0].mutations:
+        if mutation not in mutations_nd_hist:
+            mutations_nd_hist[mutation] = []
+        mutations_nd_hist[mutation].append(mutation.ccf_1d)
+    for mutation, mutation_nd_hist in mutations_nd_hist.items():
+        clustering_results[mutation.cluster_assignment].add_mutation(mutation, mutation_nd_hist)
     patient_data.ClusteringResults = clustering_results

--- a/BuildTree/CellPopulation.py
+++ b/BuildTree/CellPopulation.py
@@ -36,6 +36,8 @@ def run_tool(args):
     phylogicoutput.write_all_cell_abundances(cp_engine.get_all_cell_abundances(), args.indiv_id)
     phylogicoutput.write_constrained_ccf_tsv(constrained_ccf, cell_ancestry, args.indiv_id)
     phylogicoutput.write_cell_abundances_tsv(cell_abundance, cell_ancestry, args.indiv_id)
+    if args.cluster_ccf_trace:
+        phylogicoutput.write_cluster_ccf_trace_tsv(cp_engine.get_all_constrained_ccfs(), args.indiv_id)
     phylogicoutput.generate_html_from_tree(args.mutation_ccf_file, args.cluster_ccf_file,
                                            args.indiv_id + '_build_tree_posteriors.tsv',
                                            args.indiv_id + '_constrained_ccf.tsv',

--- a/BuildTree/CellPopulation.py
+++ b/BuildTree/CellPopulation.py
@@ -45,7 +45,8 @@ def run_tool(args):
                                            drivers=patient_data.driver_genes,
                                            treatment_file=args.treatment_data,
                                            tumor_sizes_file=args.tumor_size,
-                                           cnv_file=args.indiv_id + '.cnvs.txt')
+                                           cnv_file=args.indiv_id + '.cnvs.txt',
+                                           cluster_color_order=args.cluster_order)
 
 
 def load_tree_edges_file(tree_tsv):

--- a/BuildTree/CellPopulationEngine.py
+++ b/BuildTree/CellPopulationEngine.py
@@ -117,6 +117,16 @@ class CellPopulationEngine:
             sample_clusters_densities[cluster_id] = cluster.hist[sample_id]
         return sample_clusters_densities
 
+    def get_all_constrained_ccfs(self):
+        """ For each MCMC iteration returns constrained ccfs """
+        return self._all_configurations
+        # all_cell_ccfs = {}
+        # for sample_id, sample_constrained_ccf in self._all_configurations.items():
+        #     all_cell_ccfs[sample_id] = []
+        #     for iteration, constrained_ccf in enumerate(sample_constrained_ccf):
+        #         all_cell_ccfs[sample_id].append(constrained_ccf)
+        # return all_cell_ccfs
+
     def get_all_cell_abundances(self):
         """ For each MCMC iteration computes cell abundances """
         all_cell_abundances = {}

--- a/BuildTree/Tree.py
+++ b/BuildTree/Tree.py
@@ -342,7 +342,13 @@ class Tree:
             node.remove_parent()
         # Add new edges
         for (parent_id, child_id) in new_edges:
-            self.add_edge(self._nodes[parent_id], self._nodes[child_id])
+            if child_id not in self._nodes:
+                root = child_id == 1
+                self.add_node(child_id, root=root)
+            if parent_id:
+                self.add_edge(self._nodes[parent_id], self._nodes[child_id])
+            else:
+                self.add_edge(None, self._nodes[child_id])
 
     def get_ancestry(self, node_id):
         node = self._nodes[node_id]

--- a/PhylogicNDT.py
+++ b/PhylogicNDT.py
@@ -267,6 +267,11 @@ def build_parser():
                            dest='cluster_ccf_trace',
                            action='store_true',
                            help='Save MCMC trace for constrained CCF values (in addition to cell abundance trace)')
+    buildtree.add_argument('--cluster_order',
+                           dest='cluster_order',
+                           action='store',
+                           type=str,
+                           help='Specify order of clusters to change cluster colors (i.e. to match other tree). Give as comma-separated string.')
 
     buildtree.set_defaults(func=BuildTree.BuildTree.run_tool)
 
@@ -296,9 +301,14 @@ def build_parser():
                                 default=250,
                                 help='number iterations')
     cellpopulation.add_argument('--cluster_ccf_trace',
-                           dest='cluster_ccf_trace',
-                           action='store_true',
-                           help='Save MCMC trace for constrained CCF values (in addition to cell abundance trace)')
+                                dest='cluster_ccf_trace',
+                                action='store_true',
+                                help='Save MCMC trace for constrained CCF values (in addition to cell abundance trace)')
+    cellpopulation.add_argument('--cluster_order',
+                                dest='cluster_order',
+                                action='store',
+                                type=str,
+                                help='Specify order of clusters to change cluster colors (i.e. to match other tree). Give as comma-separated string.')
     cellpopulation.set_defaults(func=BuildTree.CellPopulation.run_tool)
 
     # GrowthKinetics  Tool

--- a/PhylogicNDT.py
+++ b/PhylogicNDT.py
@@ -263,6 +263,10 @@ def build_parser():
                             action='append',
                             type=str,
                             help="List cluster ids to blacklist from BuildTree and CellPopulation")
+    buildtree.add_argument('--cluster_ccf_trace',
+                           dest='cluster_ccf_trace',
+                           action='store_true',
+                           help='Save MCMC trace for constrained CCF values (in addition to cell abundance trace)')
 
     buildtree.set_defaults(func=BuildTree.BuildTree.run_tool)
 
@@ -291,6 +295,10 @@ def build_parser():
                                 dest='n_iter',
                                 default=250,
                                 help='number iterations')
+    cellpopulation.add_argument('--cluster_ccf_trace',
+                           dest='cluster_ccf_trace',
+                           action='store_true',
+                           help='Save MCMC trace for constrained CCF values (in addition to cell abundance trace)')
     cellpopulation.set_defaults(func=BuildTree.CellPopulation.run_tool)
 
     # GrowthKinetics  Tool

--- a/PhylogicNDT.py
+++ b/PhylogicNDT.py
@@ -272,6 +272,10 @@ def build_parser():
                            action='store',
                            type=str,
                            help='Specify order of clusters to change cluster colors (i.e. to match other tree). Give as comma-separated string.')
+    buildtree.add_argument('--select_tree',
+                           dest='select_tree',
+                           action='store_true',
+                           help='Specify if you desire to manually select the tree used for the CellPopulation module.')
 
     buildtree.set_defaults(func=BuildTree.BuildTree.run_tool)
 

--- a/PhylogicNDT.py
+++ b/PhylogicNDT.py
@@ -313,6 +313,12 @@ def build_parser():
                                 action='store',
                                 type=str,
                                 help='Specify order of clusters to change cluster colors (i.e. to match other tree). Give as comma-separated string.')
+    cellpopulation.add_argument('--tree_number',
+                                dest='tree_number',
+                                action='store',
+                                type=int,
+                                help='Specify which tree to select from the ranked build_tree_posteriors (1-indexed); default is 1 (most likely tree).',
+                                default=1)
     cellpopulation.set_defaults(func=BuildTree.CellPopulation.run_tool)
 
     # GrowthKinetics  Tool

--- a/output/PhylogicOutput.py
+++ b/output/PhylogicOutput.py
@@ -113,7 +113,7 @@ class PhylogicOutput(object):
                                treatment_data=treatment_data)
 
     def generate_html_from_tree(self, mutation_ccf_file, cluster_ccf_file, tree, abundances, sif=None, drivers=(),
-                                treatment_file=None, tumor_sizes_file=None, cnv_file=None):
+                                treatment_file=None, tumor_sizes_file=None, cnv_file=None, cluster_color_order=None):
         """
         Creates html report from Clustering and BuildTree output files
         Args:
@@ -128,6 +128,27 @@ class PhylogicOutput(object):
             cnv_file: path to cnvs file
 
         """
+        # Alter cluster colors
+        if cluster_color_order:
+            cluster_color_order = cluster_color_order.split(',')
+            default_color_list = ClusterColors.get_default_color_list()
+            needed_clusters = {int(clus): col for clus, col in
+                               zip(cluster_color_order, default_color_list[1:len(cluster_color_order)+1])}
+            remain_clusters = default_color_list[len(cluster_color_order)+1:]
+            i = 1
+            final_colors = [default_color_list[0]]  # add cluster "0" pink color
+            while needed_clusters:
+                if i in needed_clusters.keys():
+                    final_colors.append(needed_clusters.pop(i))
+                else:
+                    try:
+                        final_colors.append(remain_clusters.pop(0))
+                    except IndexError:
+                        continue
+                i += 1
+            final_colors.extend(remain_clusters)
+            ClusterColors.color_list = final_colors
+        #
         sample_names = []
         treatment_data = None
         if sif:
@@ -1397,6 +1418,7 @@ class PhylogicOutput(object):
 class ClusterColors(object):
     # Cluster colors
     color_list = [[166, 17, 129],
+                 # [211, 211, 211],  # todo remove - Gray is for unrelated clonal only
                   [39, 140, 24],
                   [103, 200, 243],
                   [248, 139, 16],
@@ -1462,6 +1484,68 @@ class ClusterColors(object):
     @classmethod
     def get_hex_string(cls, c):
         return '#{:02X}{:02X}{:02X}'.format(*cls.color_list[c])
+
+    @classmethod
+    def get_default_color_list(cls):
+        return [[166, 17, 129],
+                #[211, 211, 211],  # todo remove - Gray is for unrelated clonal only
+                  [39, 140, 24],
+                  [103, 200, 243],
+                  [248, 139, 16],
+                  [16, 49, 41],
+                  [93, 119, 254],
+                  [152, 22, 26],
+                  [104, 236, 172],
+                  [249, 142, 135],
+                  [55, 18, 48],
+                  [83, 82, 22],
+                  [247, 36, 36],
+                  [0, 79, 114],
+                  [243, 65, 132],
+                  [60, 185, 179],
+                  [185, 177, 243],
+                  [139, 34, 67],
+                  [178, 41, 186],
+                  [58, 146, 231],
+                  [130, 159, 21],
+                  [161, 91, 243],
+                  [131, 61, 17],
+                  [248, 75, 81],
+                  [32, 75, 32],
+                  [45, 109, 116],
+                  [255, 169, 199],
+                  [55, 179, 113],
+                  [34, 42, 3],
+                  [56, 121, 166],
+                  [172, 60, 15],
+                  [115, 76, 204],
+                  [21, 61, 73],
+                  [67, 21, 74],  # Additional colors, uglier and bad
+                  [123, 88, 112],
+                  [87, 106, 46],
+                  [37, 66, 58],
+                  [132, 79, 62],
+                  [71, 58, 32],
+                  [59, 104, 114],
+                  [46, 107, 90],
+                  [84, 68, 73],
+                  [90, 97, 124],
+                  [121, 66, 76],
+                  [104, 93, 48],
+                  [49, 67, 82],
+                  [71, 95, 65],
+                  [127, 85, 44],  # even more additional colors, gray
+                  [88, 79, 92],
+                  [220, 212, 194],
+                  [35, 34, 36],
+                  [200, 220, 224],
+                  [73, 81, 69],
+                  [224, 199, 206],
+                  [120, 127, 113],
+                  [142, 148, 166],
+                  [153, 167, 156],
+                  [162, 139, 145],
+                  [0, 0, 0]]  # black
 
 
 class HTMLTemplate(Template):

--- a/output/PhylogicOutput.py
+++ b/output/PhylogicOutput.py
@@ -1048,14 +1048,18 @@ class PhylogicOutput(object):
         df.to_csv(output_file, sep='\t', index=False)
 
     @staticmethod
-    def write_all_cell_abundances(all_cell_abundances, indiv_id):
-        header = ['Patient_ID', 'Sample_ID', 'Iteration', 'Cluster_ID', 'Abundance']
-        with open(indiv_id + '_cell_population_mcmc_trace.tsv', 'w') as writer:
+    def write_all_cell_abundances(all_cell_abundances, indiv_id, fn='_cell_population_mcmc_trace.tsv', head='Abundance'):
+        header = ['Patient_ID', 'Sample_ID', 'Iteration', 'Cluster_ID', head]
+        with open(indiv_id + fn, 'w') as writer:
             writer.write('\t'.join(header) + '\n')
             for sample_id, sample_mcmc_trace in all_cell_abundances.items():
                 for iteration, abundances in enumerate(sample_mcmc_trace):
                     for cluster, amount in abundances.items():
                         writer.write('\t'.join([indiv_id, sample_id, str(iteration), str(cluster), str(amount)]) + '\n')
+
+    @staticmethod
+    def write_cluster_ccf_trace_tsv(all_cell_ccfs, indiv_id):
+        PhylogicOutput.write_all_cell_abundances(all_cell_ccfs, indiv_id, fn='_cluster_ccf_mcmc_trace.tsv', head='CCF')
 
     @staticmethod
     def write_mcmc_constrained_densitites(mcmc_trace_constrained_densitites, indiv_id):


### PR DESCRIPTION
- Allows output of the cluster CCF trace with option --cluster_ccf_trace when running BuildTree or CellPopulation
- Allows for selecting the colors for non-consecutive clusters (if trying to match WES and WGS runs, for instance) by passing a comma-separated list to --cluster_order
- Allows for selecting a certain tree number (--tree_number <iter_one_indexed>) when running CellPopulation, to get the CCF Trace for a specific tree iteration
- Bug fixes in CellPopulation so it can run alone