### PR TITLE
Do not display silent mutations in the tree

### DIFF
--- a/output/PhylogicOutput.py
+++ b/output/PhylogicOutput.py
@@ -73,7 +73,12 @@ class PhylogicOutput(object):
                         if i == 0:
                             n_muts[c] += 1
                             if mut_name.split('_')[0] in drivers:
-                                c_drivers[c].append(mut_name)
+                                if "." in mut_name: #Non-coding mutations don't have this
+                                    mut_name_prot_change = mut_name.split(".")[1]
+                                    old_aa = mut_name_prot_change[0] #Previous amino acid
+                                    new_aa = mut_name_prot_change[-1] #New amino acid
+                                    if new_aa != old_aa: #If mutation is non-silent, only then add it to 'drivers'
+                                        c_drivers[c].append(mut_name)
                     else:
                         cluster_dict[c]['cnvs'].setdefault(mut_name, {'ccf_hat': [], 'alt_cnt': [], 'ref_cnt': []})
                         cluster_dict[c]['cnvs'][mut_name]['ccf_hat'].append(ccf_hat)
@@ -228,7 +233,12 @@ class PhylogicOutput(object):
                 if sample == sample_names[0]:
                     n_muts[c] += 1
                     if hugo in drivers:
-                        cluster_dict[c]['drivers'].append(mut_name)
+                        if "." in mut_name: #Non-coding mutations don't have this
+                            mut_name_prot_change = mut_name.split(".")[1]
+                            old_aa = mut_name_prot_change[0] #Previous amino acid
+                            new_aa = mut_name_prot_change[-1] #New amino acid
+                            if new_aa != old_aa: #If mutation is non-silent, only then add it to 'drivers'
+                                cluster_dict[c]['drivers'].append(mut_name)
         if cnv_file:
             unique_cnvs = {s: set() for s in sample_names}
             with open(cnv_file, 'r') as cnvs:


### PR DESCRIPTION
Checking if the mutation is non-silent before adding it to drivers list that will be displayed on the tree.